### PR TITLE
Fix dark mode contrast in documentation

### DIFF
--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -12,10 +12,14 @@ theme:
   name: material
   palette:
     - scheme: sidedoc
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
     - scheme: sidedoc-dark
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-4
         name: Switch to light mode


### PR DESCRIPTION
## Summary

This PR fixes the dark mode readability issue in the GitHub Pages documentation site where dark text appeared on a dark background.

## Changes

- Added `primary: custom` and `accent: custom` to both light and dark palette configurations in `mkdocs.yml`
- This ensures the Material theme properly uses the custom CSS color schemes already defined in `extra.css`

## Testing

The custom CSS already defines proper color schemes for both light (`sidedoc`) and dark (`sidedoc-dark`) modes with appropriate contrast:
- Light mode: Dark text (#2C3E50) on light background (#F8F9FA)
- Dark mode: Light text (#E8E8E8) on dark background (#1A1A1A)

The fix ensures these color schemes are properly applied by the Material theme.

Fixes #1