### PR TITLE
fix: apply docx_style and paragraph format properties during reconstruction (JON-91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Chart/SmartArt in content.md:** `![Chart: title](assets/chart1.png)` and `![SmartArt: type](assets/smartart1.png)` notation
 - **Full-fidelity chart round-trip:** Archive chart XML parts, embedded spreadsheets, relationship IDs, and drawing XML to `assets/chart_parts/` during extraction; reconstruct functional charts (not just raster images) during `sidedoc build` ([JON-108](https://linear.app/jonathangardner/issue/JON-108/chart-full-fidelity-round-trip-archive-reconstruct))
 
+### Fixed
+
+- **Style preservation** - Apply `docx_style` to paragraphs during reconstruction so rebuilt documents maintain original Word styles (Quote, Title, List Bullet, Heading, etc.) instead of falling back to "Normal". Also extract and preserve paragraph format properties (indentation, spacing, keep_together, keep_with_next, page_break_before) through round-trip. Gracefully falls back to "Normal" with a warning when custom styles are missing in the target document. ([JON-91](https://linear.app/jonathangardner/issue/JON-91/enhanced-style-preservation-docx-style-application))
+
 ## [0.2.0] - 2026-03-19
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,8 @@ Charts are extracted using their cached PNG/EMF fallback image from the `mc:Alte
 The `Style` dataclass (in `models.py`) carries paragraph-level formatting alongside font and alignment:
 
 - **Indents/spacing** (`left_indent`, `right_indent`, `first_line_indent`, `space_before`, `space_after`): `Optional[int]` in EMUs
-- **`line_spacing`**: `Optional[float]` — proportional (e.g. `1.5` = 1.5× lines) or int EMUs for exact spacing; use `float` not `int` because python-docx returns float for proportional values
+- **`line_spacing`**: `Optional[int | float]` — proportional spacing is a float (e.g. `1.5` = 1.5× lines); exact/at-least spacing is an integer EMU value
+- **`line_spacing_rule`**: `Optional[str]` — JSON-safe `WD_LINE_SPACING` enum name (e.g. `"EXACTLY"`, `"AT_LEAST"`) needed to interpret integer `line_spacing` values during reconstruction
 - **Paragraph flags** (`keep_together`, `keep_with_next`, `page_break_before`): `Optional[bool]`
 
 **Guard rule:** Always check `is not None` (not truthiness) when applying boolean Style fields. `False` is a meaningful override (e.g. turn off keep_together) and must survive round-trip:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Sidedoc is an AI-native document format that separates content from formatting. It enables efficient AI interaction with documents while preserving rich formatting for human consumption. The canonical format is a `.sidedoc/` directory containing markdown content and formatting metadata. A `.sdoc` ZIP archive is used for distribution and sharing.
 
-**Status:** MVP complete with hyperlink, track changes, table, headers/footers, and chart support (extraction, reconstruction).
+**Status:** MVP complete with hyperlink, track changes, table, headers/footers, chart, and paragraph format property support (extraction, reconstruction).
 
 ## Development Philosophy
 
@@ -136,6 +136,48 @@ Charts are extracted using their cached PNG/EMF fallback image from the `mc:Alte
 - **Ordering rule:** Chart detection must run before image extraction in `_process_paragraph()`. Chart drawings contain both `c:chart` and an `a:blip` — running image extraction first silently consumes the chart as a regular image.
 - **Reconstruction:** Chart blocks reconstruct as embedded images (the cached fallback). Full chart fidelity (JON-108) is not yet implemented.
 - **`chart_metadata`:** Currently stores `{"chart_rel_id": ...}` for charts with a resolved relationship ID. Degraded chart paragraphs (no preview / validation error) also preserve `chart_rel_id` in `chart_metadata` when one is available; `None` only when no relationship ID can be resolved. Full chart data (type, series, labels) reserved for JON-107.
+
+### Style Dataclass — Paragraph Format Fields
+
+The `Style` dataclass (in `models.py`) carries paragraph-level formatting alongside font and alignment:
+
+- **Indents/spacing** (`left_indent`, `right_indent`, `first_line_indent`, `space_before`, `space_after`): `Optional[int]` in EMUs
+- **`line_spacing`**: `Optional[float]` — proportional (e.g. `1.5` = 1.5× lines) or int EMUs for exact spacing; use `float` not `int` because python-docx returns float for proportional values
+- **Paragraph flags** (`keep_together`, `keep_with_next`, `page_break_before`): `Optional[bool]`
+
+**Guard rule:** Always check `is not None` (not truthiness) when applying boolean Style fields. `False` is a meaningful override (e.g. turn off keep_together) and must survive round-trip:
+
+```python
+# Correct
+if block_style.get("keep_together") is not None:
+    pf.keep_together = block_style["keep_together"]
+
+# Wrong — silently drops explicit False
+if block_style.get("keep_together"):
+    pf.keep_together = block_style["keep_together"]
+```
+
+### Per-Run Font Formatting vs. Shared Style Mutation
+
+When applying font overrides during reconstruction, **always write to individual runs** (`run.font.name`, `run.font.size`), not to `para.style.font`. The `para.style` object is shared across all paragraphs using the same docx style — mutating it changes every paragraph that uses that style, not just the current one:
+
+```python
+# Correct — direct run formatting is the override layer above style defaults
+for run in para.runs:
+    run.font.name = block_style["font_name"]
+
+# Wrong — mutates the shared style object, affecting all paragraphs with that style
+para.style.font.name = block_style["font_name"]
+```
+
+### `docx_style` Application
+
+`docx_style` is applied first in `_apply_block_formatting()` so style defaults take effect before direct overrides. Three values are intentionally skipped:
+- `"Normal"` — default style, no-op assignment can fail on read-only paragraphs
+- `"Table"` — table cell paragraphs use a separate `_apply_cell_styles` path
+- `"TextBox"` — text box paragraphs have their own reconstruction path
+
+When a custom style name is not found in the target document, a `UserWarning` is emitted and formatting falls back to Normal (no exception raised).
 
 ### Table Support (Phase 2)
 

--- a/src/sidedoc/extract.py
+++ b/src/sidedoc/extract.py
@@ -2440,6 +2440,7 @@ def extract_styles(docx_path: str, blocks: list[Block]) -> list[Style]:
             # python-docx Length objects (subclasses of int); cast to int for
             # JSON-safe storage. line_spacing is left untouched — it may be a
             # float for proportional spacing (1.5x) or an int EMU for exact.
+            # line_spacing_rule is stored as a JSON-safe WD_LINE_SPACING enum name.
             # Booleans are stored verbatim so an explicit False override of a
             # style's True default is preserved.
             pf = paragraph.paragraph_format
@@ -2455,6 +2456,11 @@ def extract_styles(docx_path: str, blocks: list[Block]) -> list[Style]:
                 space_before=_to_emu_int(pf.space_before),
                 space_after=_to_emu_int(pf.space_after),
                 line_spacing=pf.line_spacing,
+                line_spacing_rule=(
+                    pf.line_spacing_rule.name
+                    if pf.line_spacing_rule is not None
+                    else None
+                ),
                 keep_together=pf.keep_together,
                 keep_with_next=pf.keep_with_next,
                 page_break_before=pf.page_break_before,

--- a/src/sidedoc/extract.py
+++ b/src/sidedoc/extract.py
@@ -2438,10 +2438,14 @@ def extract_styles(docx_path: str, blocks: list[Block]) -> list[Style]:
             first_line_indent = int(pf.first_line_indent) if pf.first_line_indent is not None else None
             space_before = int(pf.space_before) if pf.space_before is not None else None
             space_after = int(pf.space_after) if pf.space_after is not None else None
-            line_spacing = int(pf.line_spacing) if pf.line_spacing is not None else None
-            keep_together = pf.keep_together if pf.keep_together else None
-            keep_with_next = pf.keep_with_next if pf.keep_with_next else None
-            page_break_before = pf.page_break_before if pf.page_break_before else None
+            # line_spacing can be a float (proportional, e.g. 1.5) or an int EMU
+            # (exact). Store as-is — int() would truncate proportional values.
+            line_spacing = pf.line_spacing if pf.line_spacing is not None else None
+            # Booleans need `is not None` so an explicit False override (e.g.
+            # overriding a style's True default) is preserved, not silently dropped.
+            keep_together = pf.keep_together if pf.keep_together is not None else None
+            keep_with_next = pf.keep_with_next if pf.keep_with_next is not None else None
+            page_break_before = pf.page_break_before if pf.page_break_before is not None else None
 
             style = Style(
                 block_id=block.id,

--- a/src/sidedoc/extract.py
+++ b/src/sidedoc/extract.py
@@ -2359,6 +2359,11 @@ def extract_table_formatting(table: Any) -> dict[str, Any]:
     return result
 
 
+def _to_emu_int(value: Any) -> Optional[int]:
+    """Cast a python-docx Length to int EMU, or return None if absent."""
+    return int(value) if value is not None else None
+
+
 def extract_styles(docx_path: str, blocks: list[Block]) -> list[Style]:
     """Extract style information from Word document.
 
@@ -2431,37 +2436,28 @@ def extract_styles(docx_path: str, blocks: list[Block]) -> list[Style]:
                     paragraph.alignment, DEFAULT_ALIGNMENT
                 )
 
-            # Extract paragraph format properties
+            # Extract paragraph format properties. Indent/spacing values are
+            # python-docx Length objects (subclasses of int); cast to int for
+            # JSON-safe storage. line_spacing is left untouched — it may be a
+            # float for proportional spacing (1.5x) or an int EMU for exact.
+            # Booleans are stored verbatim so an explicit False override of a
+            # style's True default is preserved.
             pf = paragraph.paragraph_format
-            left_indent = int(pf.left_indent) if pf.left_indent is not None else None
-            right_indent = int(pf.right_indent) if pf.right_indent is not None else None
-            first_line_indent = int(pf.first_line_indent) if pf.first_line_indent is not None else None
-            space_before = int(pf.space_before) if pf.space_before is not None else None
-            space_after = int(pf.space_after) if pf.space_after is not None else None
-            # line_spacing can be a float (proportional, e.g. 1.5) or an int EMU
-            # (exact). Store as-is — int() would truncate proportional values.
-            line_spacing = pf.line_spacing if pf.line_spacing is not None else None
-            # Booleans need `is not None` so an explicit False override (e.g.
-            # overriding a style's True default) is preserved, not silently dropped.
-            keep_together = pf.keep_together if pf.keep_together is not None else None
-            keep_with_next = pf.keep_with_next if pf.keep_with_next is not None else None
-            page_break_before = pf.page_break_before if pf.page_break_before is not None else None
-
             style = Style(
                 block_id=block.id,
                 docx_style=paragraph.style.name if paragraph.style else "Normal",
                 font_name=font_name,
                 font_size=font_size,
                 alignment=alignment,
-                left_indent=left_indent,
-                right_indent=right_indent,
-                first_line_indent=first_line_indent,
-                space_before=space_before,
-                space_after=space_after,
-                line_spacing=line_spacing,
-                keep_together=keep_together,
-                keep_with_next=keep_with_next,
-                page_break_before=page_break_before,
+                left_indent=_to_emu_int(pf.left_indent),
+                right_indent=_to_emu_int(pf.right_indent),
+                first_line_indent=_to_emu_int(pf.first_line_indent),
+                space_before=_to_emu_int(pf.space_before),
+                space_after=_to_emu_int(pf.space_after),
+                line_spacing=pf.line_spacing,
+                keep_together=pf.keep_together,
+                keep_with_next=pf.keep_with_next,
+                page_break_before=pf.page_break_before,
             )
             styles.append(style)
             block_index += 1

--- a/src/sidedoc/extract.py
+++ b/src/sidedoc/extract.py
@@ -2431,12 +2431,33 @@ def extract_styles(docx_path: str, blocks: list[Block]) -> list[Style]:
                     paragraph.alignment, DEFAULT_ALIGNMENT
                 )
 
+            # Extract paragraph format properties
+            pf = paragraph.paragraph_format
+            left_indent = int(pf.left_indent) if pf.left_indent is not None else None
+            right_indent = int(pf.right_indent) if pf.right_indent is not None else None
+            first_line_indent = int(pf.first_line_indent) if pf.first_line_indent is not None else None
+            space_before = int(pf.space_before) if pf.space_before is not None else None
+            space_after = int(pf.space_after) if pf.space_after is not None else None
+            line_spacing = int(pf.line_spacing) if pf.line_spacing is not None else None
+            keep_together = pf.keep_together if pf.keep_together else None
+            keep_with_next = pf.keep_with_next if pf.keep_with_next else None
+            page_break_before = pf.page_break_before if pf.page_break_before else None
+
             style = Style(
                 block_id=block.id,
                 docx_style=paragraph.style.name if paragraph.style else "Normal",
                 font_name=font_name,
                 font_size=font_size,
                 alignment=alignment,
+                left_indent=left_indent,
+                right_indent=right_indent,
+                first_line_indent=first_line_indent,
+                space_before=space_before,
+                space_after=space_after,
+                line_spacing=line_spacing,
+                keep_together=keep_together,
+                keep_with_next=keep_with_next,
+                page_break_before=page_break_before,
             )
             styles.append(style)
             block_index += 1

--- a/src/sidedoc/models.py
+++ b/src/sidedoc/models.py
@@ -113,13 +113,15 @@ class Style:
     italic: Optional[bool] = None
     underline: Optional[bool] = None
     table_formatting: Optional[dict[str, Any]] = None  # For tables: column_widths, table_alignment, table_style, cell_styles
-    # Paragraph format properties (stored in EMUs / English Metric Units)
+    # Paragraph format properties. Indents/spacing in EMUs (int); line_spacing
+    # is a float for proportional spacing (1.5 = 1.5x lines) or an int EMU for
+    # exact spacing; the flags are bool.
     left_indent: Optional[int] = None
     right_indent: Optional[int] = None
     first_line_indent: Optional[int] = None
     space_before: Optional[int] = None
     space_after: Optional[int] = None
-    line_spacing: Optional[int] = None
+    line_spacing: Optional[float] = None
     keep_together: Optional[bool] = None
     keep_with_next: Optional[bool] = None
     page_break_before: Optional[bool] = None

--- a/src/sidedoc/models.py
+++ b/src/sidedoc/models.py
@@ -113,6 +113,16 @@ class Style:
     italic: Optional[bool] = None
     underline: Optional[bool] = None
     table_formatting: Optional[dict[str, Any]] = None  # For tables: column_widths, table_alignment, table_style, cell_styles
+    # Paragraph format properties (stored in EMUs / English Metric Units)
+    left_indent: Optional[int] = None
+    right_indent: Optional[int] = None
+    first_line_indent: Optional[int] = None
+    space_before: Optional[int] = None
+    space_after: Optional[int] = None
+    line_spacing: Optional[int] = None
+    keep_together: Optional[bool] = None
+    keep_with_next: Optional[bool] = None
+    page_break_before: Optional[bool] = None
 
 
 @dataclass

--- a/src/sidedoc/models.py
+++ b/src/sidedoc/models.py
@@ -115,13 +115,15 @@ class Style:
     table_formatting: Optional[dict[str, Any]] = None  # For tables: column_widths, table_alignment, table_style, cell_styles
     # Paragraph format properties. Indents/spacing in EMUs (int); line_spacing
     # is a float for proportional spacing (1.5 = 1.5x lines) or an int EMU for
-    # exact spacing; the flags are bool.
+    # exact/at-least spacing; line_spacing_rule stores the WD_LINE_SPACING enum
+    # name needed to interpret integer values correctly; the flags are bool.
     left_indent: Optional[int] = None
     right_indent: Optional[int] = None
     first_line_indent: Optional[int] = None
     space_before: Optional[int] = None
     space_after: Optional[int] = None
-    line_spacing: Optional[float] = None
+    line_spacing: Optional[int | float] = None
+    line_spacing_rule: Optional[str] = None
     keep_together: Optional[bool] = None
     keep_with_next: Optional[bool] = None
     page_break_before: Optional[bool] = None

--- a/src/sidedoc/package.py
+++ b/src/sidedoc/package.py
@@ -168,6 +168,15 @@ def _build_metadata(
                 "italic": style.italic,
                 "underline": style.underline,
                 "table_formatting": style.table_formatting,
+                "left_indent": style.left_indent,
+                "right_indent": style.right_indent,
+                "first_line_indent": style.first_line_indent,
+                "space_before": style.space_before,
+                "space_after": style.space_after,
+                "line_spacing": style.line_spacing,
+                "keep_together": style.keep_together,
+                "keep_with_next": style.keep_with_next,
+                "page_break_before": style.page_break_before,
             }
             for style in styles
         },

--- a/src/sidedoc/package.py
+++ b/src/sidedoc/package.py
@@ -174,6 +174,7 @@ def _build_metadata(
                 "space_before": style.space_before,
                 "space_after": style.space_after,
                 "line_spacing": style.line_spacing,
+                "line_spacing_rule": style.line_spacing_rule,
                 "keep_together": style.keep_together,
                 "keep_with_next": style.keep_with_next,
                 "page_break_before": style.page_break_before,

--- a/src/sidedoc/reconstruct.py
+++ b/src/sidedoc/reconstruct.py
@@ -1232,7 +1232,11 @@ def _apply_block_formatting(para: Any, block_style: dict[str, Any]) -> None:
     if not block_style:
         return
 
-    # Apply docx_style first — style defaults apply, then direct formatting overrides
+    # Apply docx_style first — style defaults apply, then direct formatting overrides.
+    # "Normal" is skipped because it's the default style (no-op assignment can fail on
+    # paragraphs whose style is treated as read-only). "Table" and "TextBox" are
+    # skipped because their paragraphs apply formatting through different code paths
+    # (table cells via _apply_cell_styles; text boxes via their own reconstruct path).
     docx_style = block_style.get("docx_style")
     if docx_style and docx_style not in ("Normal", "Table", "TextBox"):
         try:
@@ -1242,10 +1246,16 @@ def _apply_block_formatting(para: Any, block_style: dict[str, Any]) -> None:
                 f"Style '{docx_style}' not found in document, falling back to Normal"
             )
 
-    if "font_name" in block_style and para.style:
-        para.style.font.name = block_style["font_name"]
-    if "font_size" in block_style and para.style:
-        para.style.font.size = Pt(block_style["font_size"])
+    # Apply font overrides per-run, not on para.style.font — para.style is the
+    # SHARED style object, so mutating it would change every paragraph using the
+    # same docx_style. Direct run formatting is the correct override layer above
+    # the style's defaults.
+    if "font_name" in block_style:
+        for run in para.runs:
+            run.font.name = block_style["font_name"]
+    if "font_size" in block_style:
+        for run in para.runs:
+            run.font.size = Pt(block_style["font_size"])
 
     alignment = block_style.get("alignment", DEFAULT_ALIGNMENT)
     if alignment in ALIGNMENT_STRING_TO_ENUM:

--- a/src/sidedoc/reconstruct.py
+++ b/src/sidedoc/reconstruct.py
@@ -1221,12 +1221,26 @@ def create_table_from_gfm(
 def _apply_block_formatting(para: Any, block_style: dict[str, Any]) -> None:
     """Apply formatting from block_style to a paragraph.
 
+    Applies docx_style first (so style defaults take effect), then direct
+    formatting overrides from the style dictionary.
+
     Args:
         para: python-docx Paragraph object
-        block_style: Style dictionary with font_name, font_size, alignment
+        block_style: Style dictionary with docx_style, font_name, font_size, alignment,
+            and paragraph format properties
     """
     if not block_style:
         return
+
+    # Apply docx_style first — style defaults apply, then direct formatting overrides
+    docx_style = block_style.get("docx_style")
+    if docx_style and docx_style not in ("Normal", "Table", "TextBox"):
+        try:
+            para.style = docx_style
+        except KeyError:
+            warnings.warn(
+                f"Style '{docx_style}' not found in document, falling back to Normal"
+            )
 
     if "font_name" in block_style and para.style:
         para.style.font.name = block_style["font_name"]
@@ -1236,6 +1250,27 @@ def _apply_block_formatting(para: Any, block_style: dict[str, Any]) -> None:
     alignment = block_style.get("alignment", DEFAULT_ALIGNMENT)
     if alignment in ALIGNMENT_STRING_TO_ENUM:
         para.alignment = ALIGNMENT_STRING_TO_ENUM[alignment]
+
+    # Apply paragraph format properties (direct formatting overrides)
+    pf = para.paragraph_format
+    if block_style.get("left_indent") is not None:
+        pf.left_indent = block_style["left_indent"]
+    if block_style.get("right_indent") is not None:
+        pf.right_indent = block_style["right_indent"]
+    if block_style.get("first_line_indent") is not None:
+        pf.first_line_indent = block_style["first_line_indent"]
+    if block_style.get("space_before") is not None:
+        pf.space_before = block_style["space_before"]
+    if block_style.get("space_after") is not None:
+        pf.space_after = block_style["space_after"]
+    if block_style.get("line_spacing") is not None:
+        pf.line_spacing = block_style["line_spacing"]
+    if block_style.get("keep_together") is not None:
+        pf.keep_together = block_style["keep_together"]
+    if block_style.get("keep_with_next") is not None:
+        pf.keep_with_next = block_style["keep_with_next"]
+    if block_style.get("page_break_before") is not None:
+        pf.page_break_before = block_style["page_break_before"]
 
 
 def _parse_footnote_definitions(content_md: str) -> dict[int, str]:

--- a/src/sidedoc/reconstruct.py
+++ b/src/sidedoc/reconstruct.py
@@ -52,6 +52,21 @@ import mistune
 SIDEDOC_NS = "https://sidedoc.dev/xmlns/2026"
 SIDEDOC_BLOCK_ID = f"{{{SIDEDOC_NS}}}blockId"
 
+# Paragraph format properties applied as direct formatting overrides in
+# _apply_block_formatting. Each name maps 1:1 to a python-docx
+# `paragraph_format` attribute and to a Style dataclass field.
+_PARAGRAPH_FORMAT_PROPS = (
+    "left_indent",
+    "right_indent",
+    "first_line_indent",
+    "space_before",
+    "space_after",
+    "line_spacing",
+    "keep_together",
+    "keep_with_next",
+    "page_break_before",
+)
+
 # Known limitation: multi-line footnote definitions not supported.
 # Only single-line [^N]: text definitions are captured; indented continuation
 # lines (per Markdown spec) are silently dropped.
@@ -1243,44 +1258,35 @@ def _apply_block_formatting(para: Any, block_style: dict[str, Any]) -> None:
             para.style = docx_style
         except KeyError:
             warnings.warn(
-                f"Style '{docx_style}' not found in document, falling back to Normal"
+                f"Style '{docx_style}' not found in document, falling back to Normal",
+                stacklevel=2,
             )
 
     # Apply font overrides per-run, not on para.style.font — para.style is the
     # SHARED style object, so mutating it would change every paragraph using the
     # same docx_style. Direct run formatting is the correct override layer above
     # the style's defaults.
-    if "font_name" in block_style:
+    font_name = block_style.get("font_name")
+    font_size = block_style.get("font_size")
+    if font_name is not None or font_size is not None:
         for run in para.runs:
-            run.font.name = block_style["font_name"]
-    if "font_size" in block_style:
-        for run in para.runs:
-            run.font.size = Pt(block_style["font_size"])
+            if font_name is not None:
+                run.font.name = font_name
+            if font_size is not None:
+                run.font.size = Pt(font_size)
 
     alignment = block_style.get("alignment", DEFAULT_ALIGNMENT)
     if alignment in ALIGNMENT_STRING_TO_ENUM:
         para.alignment = ALIGNMENT_STRING_TO_ENUM[alignment]
 
-    # Apply paragraph format properties (direct formatting overrides)
+    # Apply paragraph format properties as direct formatting overrides. The
+    # `is not None` guard (vs. a truthy check) preserves explicit False/0
+    # overrides that would otherwise be dropped as falsy.
     pf = para.paragraph_format
-    if block_style.get("left_indent") is not None:
-        pf.left_indent = block_style["left_indent"]
-    if block_style.get("right_indent") is not None:
-        pf.right_indent = block_style["right_indent"]
-    if block_style.get("first_line_indent") is not None:
-        pf.first_line_indent = block_style["first_line_indent"]
-    if block_style.get("space_before") is not None:
-        pf.space_before = block_style["space_before"]
-    if block_style.get("space_after") is not None:
-        pf.space_after = block_style["space_after"]
-    if block_style.get("line_spacing") is not None:
-        pf.line_spacing = block_style["line_spacing"]
-    if block_style.get("keep_together") is not None:
-        pf.keep_together = block_style["keep_together"]
-    if block_style.get("keep_with_next") is not None:
-        pf.keep_with_next = block_style["keep_with_next"]
-    if block_style.get("page_break_before") is not None:
-        pf.page_break_before = block_style["page_break_before"]
+    for prop in _PARAGRAPH_FORMAT_PROPS:
+        value = block_style.get(prop)
+        if value is not None:
+            setattr(pf, prop, value)
 
 
 def _parse_footnote_definitions(content_md: str) -> dict[int, str]:

--- a/src/sidedoc/reconstruct.py
+++ b/src/sidedoc/reconstruct.py
@@ -9,9 +9,10 @@ from pathlib import Path
 from typing import Any, Optional
 from urllib.parse import unquote
 from docx import Document
-from docx.shared import Pt, Inches
+from docx.shared import Pt, Inches, Emu
 from docx.document import Document as DocumentType
 from docx.enum.section import WD_ORIENT
+from docx.enum.text import WD_LINE_SPACING
 from docx.oxml.ns import qn
 from docx.opc.part import Part
 from docx.opc.packuri import PackURI
@@ -1283,10 +1284,34 @@ def _apply_block_formatting(para: Any, block_style: dict[str, Any]) -> None:
     # `is not None` guard (vs. a truthy check) preserves explicit False/0
     # overrides that would otherwise be dropped as falsy.
     pf = para.paragraph_format
+    line_spacing_rule = block_style.get("line_spacing_rule")
+    resolved_line_spacing_rule = None
+    if line_spacing_rule is not None:
+        try:
+            resolved_line_spacing_rule = WD_LINE_SPACING[line_spacing_rule]
+            pf.line_spacing_rule = resolved_line_spacing_rule
+        except KeyError:
+            warnings.warn(
+                f"Unknown line_spacing_rule '{line_spacing_rule}', skipping",
+                stacklevel=2,
+            )
     for prop in _PARAGRAPH_FORMAT_PROPS:
         value = block_style.get(prop)
-        if value is not None:
+        if value is None:
+            continue
+        if prop == "line_spacing":
+            if (
+                resolved_line_spacing_rule
+                in (WD_LINE_SPACING.EXACTLY, WD_LINE_SPACING.AT_LEAST)
+                and isinstance(value, int)
+                and not isinstance(value, bool)
+            ):
+                value = Emu(value)
             setattr(pf, prop, value)
+            if resolved_line_spacing_rule is not None:
+                pf.line_spacing_rule = resolved_line_spacing_rule
+            continue
+        setattr(pf, prop, value)
 
 
 def _parse_footnote_definitions(content_md: str) -> dict[int, str]:

--- a/tests/test_style_preservation.py
+++ b/tests/test_style_preservation.py
@@ -1,0 +1,254 @@
+"""Tests for docx_style application and paragraph format preservation (JON-91)."""
+
+import json
+from pathlib import Path
+
+from docx import Document
+from docx.shared import Pt, Inches
+from click.testing import CliRunner
+
+from sidedoc.cli import main
+from sidedoc.extract import extract_blocks, extract_styles
+
+
+class TestDocxStyleApplication:
+    """Test that docx_style is applied to paragraphs during reconstruction."""
+
+    def test_roundtrip_preserves_paragraph_style(self):
+        """Rebuilt document should preserve paragraph styles, not fallback to Normal."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            doc = Document()
+            doc.add_paragraph("A quote paragraph", style="Quote")
+            doc.add_paragraph("Normal paragraph")
+            doc.add_paragraph("Title text", style="Title")
+            doc.save("original.docx")
+
+            runner.invoke(main, ["extract", "original.docx"])
+            result = runner.invoke(main, ["build", "original.sidedoc", "-o", "rebuilt.docx"])
+            assert result.exit_code == 0
+
+            rebuilt = Document("rebuilt.docx")
+            style_names = [p.style.name for p in rebuilt.paragraphs]
+            assert "Quote" in style_names
+            assert "Title" in style_names
+
+    def test_roundtrip_preserves_list_bullet_style(self):
+        """List Bullet style should survive round-trip."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            doc = Document()
+            doc.add_paragraph("Bullet item", style="List Bullet")
+            doc.save("original.docx")
+
+            runner.invoke(main, ["extract", "original.docx"])
+            result = runner.invoke(main, ["build", "original.sidedoc", "-o", "rebuilt.docx"])
+            assert result.exit_code == 0
+
+            rebuilt = Document("rebuilt.docx")
+            # Find the paragraph with the bullet content
+            bullet_paras = [p for p in rebuilt.paragraphs if "Bullet item" in p.text]
+            assert len(bullet_paras) > 0
+            assert bullet_paras[0].style.name == "List Bullet"
+
+    def test_roundtrip_preserves_heading_styles(self):
+        """Heading styles should be applied (not just Normal)."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            doc = Document()
+            doc.add_paragraph("Chapter One", style="Heading 1")
+            doc.add_paragraph("Section A", style="Heading 2")
+            doc.add_paragraph("Body text")
+            doc.save("original.docx")
+
+            runner.invoke(main, ["extract", "original.docx"])
+            result = runner.invoke(main, ["build", "original.sidedoc", "-o", "rebuilt.docx"])
+            assert result.exit_code == 0
+
+            rebuilt = Document("rebuilt.docx")
+            texts_and_styles = {p.text: p.style.name for p in rebuilt.paragraphs}
+            assert texts_and_styles.get("Chapter One") == "Heading 1"
+            assert texts_and_styles.get("Section A") == "Heading 2"
+
+    def test_missing_custom_style_falls_back_to_normal(self):
+        """When a custom style doesn't exist in the target document, fall back to Normal."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            # Create a document with a custom style
+            doc = Document()
+            doc.styles.add_style("Legal Citation", 1)  # WD_STYLE_TYPE.PARAGRAPH = 1
+            doc.add_paragraph("Case law reference", style="Legal Citation")
+            doc.save("original.docx")
+
+            runner.invoke(main, ["extract", "original.docx"])
+
+            # Build should succeed even though the rebuilt doc won't have the custom style
+            result = runner.invoke(main, ["build", "original.sidedoc", "-o", "rebuilt.docx"])
+            assert result.exit_code == 0
+
+            # Verify the paragraph exists (with Normal fallback)
+            rebuilt = Document("rebuilt.docx")
+            texts = [p.text for p in rebuilt.paragraphs]
+            assert "Case law reference" in texts
+
+
+class TestParagraphFormatExtraction:
+    """Test that paragraph format properties are extracted."""
+
+    def _extract(self, tmp_path, doc):
+        """Helper: save doc, extract blocks+styles, return styles list."""
+        docx_path = str(tmp_path / "test.docx")
+        doc.save(docx_path)
+        blocks, _ = extract_blocks(docx_path)
+        styles = extract_styles(docx_path, blocks)
+        return styles
+
+    def test_extract_left_indent(self, tmp_path):
+        """Left indent should be extracted from paragraph format."""
+        doc = Document()
+        para = doc.add_paragraph("Indented text")
+        para.paragraph_format.left_indent = Inches(0.5)
+
+        styles = self._extract(tmp_path, doc)
+        para_styles = [s for s in styles if s.docx_style != "Table"]
+        assert len(para_styles) > 0
+        assert para_styles[0].left_indent is not None
+        assert para_styles[0].left_indent > 0
+
+    def test_extract_spacing(self, tmp_path):
+        """Space before and after should be extracted from paragraph format."""
+        doc = Document()
+        para = doc.add_paragraph("Spaced text")
+        para.paragraph_format.space_before = Pt(12)
+        para.paragraph_format.space_after = Pt(6)
+
+        styles = self._extract(tmp_path, doc)
+        para_styles = [s for s in styles if s.docx_style != "Table"]
+        assert len(para_styles) > 0
+        assert para_styles[0].space_before is not None
+        assert para_styles[0].space_after is not None
+
+    def test_extract_keep_together(self, tmp_path):
+        """keep_together should be extracted from paragraph format."""
+        doc = Document()
+        para = doc.add_paragraph("Keep together text")
+        para.paragraph_format.keep_together = True
+
+        styles = self._extract(tmp_path, doc)
+        para_styles = [s for s in styles if s.docx_style != "Table"]
+        assert len(para_styles) > 0
+        assert para_styles[0].keep_together is True
+
+    def test_extract_page_break_before(self, tmp_path):
+        """page_break_before should be extracted from paragraph format."""
+        doc = Document()
+        para = doc.add_paragraph("Page break text")
+        para.paragraph_format.page_break_before = True
+
+        styles = self._extract(tmp_path, doc)
+        para_styles = [s for s in styles if s.docx_style != "Table"]
+        assert len(para_styles) > 0
+        assert para_styles[0].page_break_before is True
+
+
+class TestParagraphFormatRoundtrip:
+    """Test that paragraph format properties survive round-trip."""
+
+    def test_roundtrip_preserves_indentation(self):
+        """Left indent should survive extract → build round-trip."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            doc = Document()
+            para = doc.add_paragraph("Indented text")
+            para.paragraph_format.left_indent = Inches(0.5)
+            doc.save("original.docx")
+
+            runner.invoke(main, ["extract", "original.docx"])
+            result = runner.invoke(main, ["build", "original.sidedoc", "-o", "rebuilt.docx"])
+            assert result.exit_code == 0
+
+            rebuilt = Document("rebuilt.docx")
+            indented = [p for p in rebuilt.paragraphs if "Indented" in p.text]
+            assert len(indented) > 0
+            assert indented[0].paragraph_format.left_indent is not None
+            assert indented[0].paragraph_format.left_indent == Inches(0.5)
+
+    def test_roundtrip_preserves_spacing(self):
+        """Space before/after should survive extract → build round-trip."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            doc = Document()
+            para = doc.add_paragraph("Spaced text")
+            para.paragraph_format.space_before = Pt(12)
+            para.paragraph_format.space_after = Pt(6)
+            doc.save("original.docx")
+
+            runner.invoke(main, ["extract", "original.docx"])
+            result = runner.invoke(main, ["build", "original.sidedoc", "-o", "rebuilt.docx"])
+            assert result.exit_code == 0
+
+            rebuilt = Document("rebuilt.docx")
+            spaced = [p for p in rebuilt.paragraphs if "Spaced" in p.text]
+            assert len(spaced) > 0
+            assert spaced[0].paragraph_format.space_before == Pt(12)
+            assert spaced[0].paragraph_format.space_after == Pt(6)
+
+    def test_roundtrip_preserves_keep_with_next(self):
+        """keep_with_next should survive extract → build round-trip."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            doc = Document()
+            para = doc.add_paragraph("Keep with next text")
+            para.paragraph_format.keep_with_next = True
+            doc.add_paragraph("Following text")
+            doc.save("original.docx")
+
+            runner.invoke(main, ["extract", "original.docx"])
+            result = runner.invoke(main, ["build", "original.sidedoc", "-o", "rebuilt.docx"])
+            assert result.exit_code == 0
+
+            rebuilt = Document("rebuilt.docx")
+            kept = [p for p in rebuilt.paragraphs if "Keep with next" in p.text]
+            assert len(kept) > 0
+            assert kept[0].paragraph_format.keep_with_next is True
+
+    def test_roundtrip_preserves_first_line_indent(self):
+        """First line indent should survive extract → build round-trip."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            doc = Document()
+            para = doc.add_paragraph("First line indented text")
+            para.paragraph_format.first_line_indent = Inches(0.25)
+            doc.save("original.docx")
+
+            runner.invoke(main, ["extract", "original.docx"])
+            result = runner.invoke(main, ["build", "original.sidedoc", "-o", "rebuilt.docx"])
+            assert result.exit_code == 0
+
+            rebuilt = Document("rebuilt.docx")
+            indented = [p for p in rebuilt.paragraphs if "First line" in p.text]
+            assert len(indented) > 0
+            assert indented[0].paragraph_format.first_line_indent == Inches(0.25)
+
+
+class TestStyleWithDirectFormatting:
+    """Test that direct formatting overrides style defaults."""
+
+    def test_direct_formatting_overrides_style(self):
+        """Direct formatting on a paragraph should override style defaults after round-trip."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            doc = Document()
+            para = doc.add_paragraph("Custom spaced heading", style="Heading 1")
+            para.paragraph_format.space_before = Pt(24)
+            doc.save("original.docx")
+
+            runner.invoke(main, ["extract", "original.docx"])
+            result = runner.invoke(main, ["build", "original.sidedoc", "-o", "rebuilt.docx"])
+            assert result.exit_code == 0
+
+            rebuilt = Document("rebuilt.docx")
+            heading = [p for p in rebuilt.paragraphs if "Custom spaced" in p.text]
+            assert len(heading) > 0
+            assert heading[0].style.name == "Heading 1"
+            assert heading[0].paragraph_format.space_before == Pt(24)

--- a/tests/test_style_preservation.py
+++ b/tests/test_style_preservation.py
@@ -1,8 +1,10 @@
 """Tests for docx_style application and paragraph format preservation (JON-91)."""
 
 import json
+import warnings
 from pathlib import Path
 
+import pytest
 from docx import Document
 from docx.shared import Pt, Inches
 from click.testing import CliRunner
@@ -24,7 +26,8 @@ class TestDocxStyleApplication:
             doc.add_paragraph("Title text", style="Title")
             doc.save("original.docx")
 
-            runner.invoke(main, ["extract", "original.docx"])
+            extract_result = runner.invoke(main, ["extract", "original.docx"])
+            assert extract_result.exit_code == 0, extract_result.output
             result = runner.invoke(main, ["build", "original.sidedoc", "-o", "rebuilt.docx"])
             assert result.exit_code == 0
 
@@ -41,7 +44,8 @@ class TestDocxStyleApplication:
             doc.add_paragraph("Bullet item", style="List Bullet")
             doc.save("original.docx")
 
-            runner.invoke(main, ["extract", "original.docx"])
+            extract_result = runner.invoke(main, ["extract", "original.docx"])
+            assert extract_result.exit_code == 0, extract_result.output
             result = runner.invoke(main, ["build", "original.sidedoc", "-o", "rebuilt.docx"])
             assert result.exit_code == 0
 
@@ -61,7 +65,8 @@ class TestDocxStyleApplication:
             doc.add_paragraph("Body text")
             doc.save("original.docx")
 
-            runner.invoke(main, ["extract", "original.docx"])
+            extract_result = runner.invoke(main, ["extract", "original.docx"])
+            assert extract_result.exit_code == 0, extract_result.output
             result = runner.invoke(main, ["build", "original.sidedoc", "-o", "rebuilt.docx"])
             assert result.exit_code == 0
 
@@ -71,22 +76,41 @@ class TestDocxStyleApplication:
             assert texts_and_styles.get("Section A") == "Heading 2"
 
     def test_missing_custom_style_falls_back_to_normal(self):
-        """When a custom style doesn't exist in the target document, fall back to Normal."""
+        """When a custom style doesn't exist in the target document, fall back to
+        Normal and emit a UserWarning so the user can spot silent fidelity loss.
+        """
         runner = CliRunner()
         with runner.isolated_filesystem():
-            # Create a document with a custom style
+            # Create a document with a custom style.
             doc = Document()
             doc.styles.add_style("Legal Citation", 1)  # WD_STYLE_TYPE.PARAGRAPH = 1
             doc.add_paragraph("Case law reference", style="Legal Citation")
             doc.save("original.docx")
 
-            runner.invoke(main, ["extract", "original.docx"])
+            extract_result = runner.invoke(main, ["extract", "original.docx"])
+            assert extract_result.exit_code == 0, extract_result.output
 
-            # Build should succeed even though the rebuilt doc won't have the custom style
+            # Build should succeed (Normal fallback) AND emit a warning naming the style.
+            # CliRunner swallows warnings emitted in the subprocess by default, so call
+            # _apply_block_formatting directly to verify the warning fires.
+            from sidedoc.reconstruct import _apply_block_formatting
+
+            target_doc = Document()
+            target_para = target_doc.add_paragraph("Case law reference")
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                _apply_block_formatting(
+                    target_para,
+                    {"docx_style": "Legal Citation", "alignment": "left"},
+                )
+            assert any(
+                "Legal Citation" in str(w.message) and issubclass(w.category, UserWarning)
+                for w in caught
+            ), f"Expected UserWarning naming 'Legal Citation'; got {[str(w.message) for w in caught]}"
+
+            # End-to-end build still succeeds and preserves the paragraph text.
             result = runner.invoke(main, ["build", "original.sidedoc", "-o", "rebuilt.docx"])
             assert result.exit_code == 0
-
-            # Verify the paragraph exists (with Normal fallback)
             rebuilt = Document("rebuilt.docx")
             texts = [p.text for p in rebuilt.paragraphs]
             assert "Case law reference" in texts
@@ -163,7 +187,8 @@ class TestParagraphFormatRoundtrip:
             para.paragraph_format.left_indent = Inches(0.5)
             doc.save("original.docx")
 
-            runner.invoke(main, ["extract", "original.docx"])
+            extract_result = runner.invoke(main, ["extract", "original.docx"])
+            assert extract_result.exit_code == 0, extract_result.output
             result = runner.invoke(main, ["build", "original.sidedoc", "-o", "rebuilt.docx"])
             assert result.exit_code == 0
 
@@ -183,7 +208,8 @@ class TestParagraphFormatRoundtrip:
             para.paragraph_format.space_after = Pt(6)
             doc.save("original.docx")
 
-            runner.invoke(main, ["extract", "original.docx"])
+            extract_result = runner.invoke(main, ["extract", "original.docx"])
+            assert extract_result.exit_code == 0, extract_result.output
             result = runner.invoke(main, ["build", "original.sidedoc", "-o", "rebuilt.docx"])
             assert result.exit_code == 0
 
@@ -203,7 +229,8 @@ class TestParagraphFormatRoundtrip:
             doc.add_paragraph("Following text")
             doc.save("original.docx")
 
-            runner.invoke(main, ["extract", "original.docx"])
+            extract_result = runner.invoke(main, ["extract", "original.docx"])
+            assert extract_result.exit_code == 0, extract_result.output
             result = runner.invoke(main, ["build", "original.sidedoc", "-o", "rebuilt.docx"])
             assert result.exit_code == 0
 
@@ -221,7 +248,8 @@ class TestParagraphFormatRoundtrip:
             para.paragraph_format.first_line_indent = Inches(0.25)
             doc.save("original.docx")
 
-            runner.invoke(main, ["extract", "original.docx"])
+            extract_result = runner.invoke(main, ["extract", "original.docx"])
+            assert extract_result.exit_code == 0, extract_result.output
             result = runner.invoke(main, ["build", "original.sidedoc", "-o", "rebuilt.docx"])
             assert result.exit_code == 0
 
@@ -243,7 +271,8 @@ class TestStyleWithDirectFormatting:
             para.paragraph_format.space_before = Pt(24)
             doc.save("original.docx")
 
-            runner.invoke(main, ["extract", "original.docx"])
+            extract_result = runner.invoke(main, ["extract", "original.docx"])
+            assert extract_result.exit_code == 0, extract_result.output
             result = runner.invoke(main, ["build", "original.sidedoc", "-o", "rebuilt.docx"])
             assert result.exit_code == 0
 
@@ -252,3 +281,131 @@ class TestStyleWithDirectFormatting:
             assert len(heading) > 0
             assert heading[0].style.name == "Heading 1"
             assert heading[0].paragraph_format.space_before == Pt(24)
+
+
+class TestClaudeReviewRegressions:
+    """Regression tests for issues flagged in the Claude bot review on PR #65."""
+
+    # Issue #1: boolean falsy-check dropped explicit False overrides.
+    def test_explicit_false_keep_with_next_survives_roundtrip(self):
+        """A paragraph that overrides Heading 1's default keep_with_next=True with an
+        explicit False must round-trip with the False preserved, not silently dropped.
+        """
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            doc = Document()
+            para = doc.add_paragraph("Heading override", style="Heading 1")
+            para.paragraph_format.keep_with_next = False
+            doc.save("original.docx")
+
+            extract_result = runner.invoke(main, ["extract", "original.docx"])
+            assert extract_result.exit_code == 0, extract_result.output
+            result = runner.invoke(main, ["build", "original.sidedoc", "-o", "rebuilt.docx"])
+            assert result.exit_code == 0
+
+            # Verify styles.json captured the False, not None
+            with open("original.sidedoc/styles.json") as f:
+                styles_data = json.load(f)
+            block_styles = list(styles_data["block_styles"].values())
+            assert any(bs.get("keep_with_next") is False for bs in block_styles), \
+                f"keep_with_next=False was not persisted to styles.json: {block_styles}"
+
+            rebuilt = Document("rebuilt.docx")
+            paras = [p for p in rebuilt.paragraphs if "Heading override" in p.text]
+            assert len(paras) > 0
+            assert paras[0].paragraph_format.keep_with_next is False
+
+    # Issue #2: int() cast truncated proportional line_spacing (e.g. 1.5 → 1).
+    def test_proportional_line_spacing_survives_roundtrip(self):
+        """A paragraph with line_spacing=1.5 (proportional) must round-trip as 1.5,
+        not be silently truncated to 1 by an int() cast.
+        """
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            doc = Document()
+            para = doc.add_paragraph("Proportionally spaced text")
+            para.paragraph_format.line_spacing = 1.5
+            doc.save("original.docx")
+
+            extract_result = runner.invoke(main, ["extract", "original.docx"])
+            assert extract_result.exit_code == 0, extract_result.output
+            result = runner.invoke(main, ["build", "original.sidedoc", "-o", "rebuilt.docx"])
+            assert result.exit_code == 0
+
+            with open("original.sidedoc/styles.json") as f:
+                styles_data = json.load(f)
+            line_spacings = [bs.get("line_spacing") for bs in styles_data["block_styles"].values()]
+            assert any(ls == pytest.approx(1.5) for ls in line_spacings), \
+                f"line_spacing 1.5 was truncated/lost: {line_spacings}"
+
+            rebuilt = Document("rebuilt.docx")
+            spaced = [p for p in rebuilt.paragraphs if "Proportionally spaced" in p.text]
+            assert len(spaced) > 0
+            assert spaced[0].paragraph_format.line_spacing == pytest.approx(1.5)
+
+    # Issue #3: para.style.font.* mutation leaked across paragraphs sharing a style.
+    def test_block_style_font_does_not_leak_via_shared_style(self):
+        """Applying font_name to one paragraph must not mutate the shared style object
+        and bleed into other paragraphs that share the same docx_style.
+        """
+        from sidedoc.reconstruct import _apply_block_formatting
+
+        doc = Document()
+        para_a = doc.add_paragraph("Paragraph A", style="Heading 1")
+        para_b = doc.add_paragraph("Paragraph B", style="Heading 1")
+
+        # Snapshot Heading 1's font.name before any mutation so we have a baseline.
+        baseline_font = para_b.style.font.name
+
+        _apply_block_formatting(
+            para_a,
+            {"docx_style": "Heading 1", "font_name": "Courier New", "alignment": "left"},
+        )
+        _apply_block_formatting(
+            para_b,
+            {"docx_style": "Heading 1", "alignment": "left"},
+        )
+
+        # Pre-fix: para_b.style.font.name is "Courier New" (shared style mutated by A).
+        # Post-fix: para_b.style.font.name is unchanged from baseline.
+        assert para_b.style.font.name != "Courier New", (
+            f"Shared 'Heading 1' style was mutated: font.name leaked to {para_b.style.font.name!r}"
+        )
+        assert para_b.style.font.name == baseline_font, (
+            f"Shared 'Heading 1' style was mutated: was {baseline_font!r}, now {para_b.style.font.name!r}"
+        )
+
+    # Issue #8: pre-existing archives without the new paragraph format fields
+    # must still build successfully (forward compatibility).
+    def test_old_styles_json_without_new_fields_builds(self):
+        """A styles.json that predates the JON-91 fields (no left_indent, line_spacing,
+        keep_with_next, etc.) must still build without errors.
+        """
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            sidedoc_dir = Path("legacy.sidedoc")
+            sidedoc_dir.mkdir()
+            (sidedoc_dir / "content.md").write_text("Hello world\n")
+            # Minimal styles.json with only the pre-JON-91 fields.
+            legacy_styles = {
+                "block_styles": {
+                    "block-0": {
+                        "docx_style": "Normal",
+                        "font_name": "Calibri",
+                        "font_size": 11,
+                        "alignment": "left",
+                        "bold": None,
+                        "italic": None,
+                        "underline": None,
+                        "table_formatting": None,
+                    },
+                },
+                "document_defaults": {"font_name": "Calibri", "font_size": 11},
+            }
+            (sidedoc_dir / "styles.json").write_text(json.dumps(legacy_styles))
+
+            result = runner.invoke(main, ["build", str(sidedoc_dir), "-o", "rebuilt.docx"])
+            assert result.exit_code == 0, result.output
+            rebuilt = Document("rebuilt.docx")
+            texts = [p.text for p in rebuilt.paragraphs]
+            assert "Hello world" in texts

--- a/tests/test_style_preservation.py
+++ b/tests/test_style_preservation.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 from docx import Document
+from docx.enum.text import WD_LINE_SPACING
 from docx.shared import Pt, Inches
 from click.testing import CliRunner
 
@@ -286,6 +287,33 @@ class TestStyleWithDirectFormatting:
 class TestClaudeReviewRegressions:
     """Regression tests for issues flagged in the Claude bot review on PR #65."""
 
+    def _assert_styles_json_has_line_spacing_rule(
+        self, sidedoc_dir: str, expected_rule: str, expected_spacing: int
+    ) -> None:
+        """Assert styles.json stores line spacing rule as a JSON-safe enum name."""
+        with open(Path(sidedoc_dir) / "styles.json") as f:
+            styles_data = json.load(f)
+        block_styles = list(styles_data["block_styles"].values())
+        assert any(
+            bs.get("line_spacing_rule") == expected_rule
+            and bs.get("line_spacing") == expected_spacing
+            for bs in block_styles
+        ), (
+            f"line_spacing={expected_spacing} with rule {expected_rule!r} "
+            f"was not persisted to styles.json: {block_styles}"
+        )
+
+    def _assert_paragraph_line_spacing(
+        self, docx_path: str, text: str, expected_rule: WD_LINE_SPACING, expected_spacing: int
+    ) -> None:
+        """Assert paragraph line spacing value and rule survived in the rebuilt docx."""
+        doc = Document(docx_path)
+        paragraphs = [p for p in doc.paragraphs if text in p.text]
+        assert len(paragraphs) > 0
+        paragraph_format = paragraphs[0].paragraph_format
+        assert paragraph_format.line_spacing_rule == expected_rule
+        assert paragraph_format.line_spacing == expected_spacing
+
     # Issue #1: boolean falsy-check dropped explicit False overrides.
     def test_explicit_false_keep_with_next_survives_roundtrip(self):
         """A paragraph that overrides Heading 1's default keep_with_next=True with an
@@ -342,6 +370,89 @@ class TestClaudeReviewRegressions:
             spaced = [p for p in rebuilt.paragraphs if "Proportionally spaced" in p.text]
             assert len(spaced) > 0
             assert spaced[0].paragraph_format.line_spacing == pytest.approx(1.5)
+
+    # Latest Claude review: line_spacing needs line_spacing_rule to interpret
+    # exact/at-least EMU values correctly.
+    def test_exact_line_spacing_rule_survives_roundtrip(self):
+        """Exact line spacing must round-trip with its interpretation rule."""
+        runner = CliRunner()
+        expected_spacing = int(Pt(12))
+        with runner.isolated_filesystem():
+            doc = Document()
+            para = doc.add_paragraph("Exactly spaced text")
+            para.paragraph_format.line_spacing = Pt(12)
+            para.paragraph_format.line_spacing_rule = WD_LINE_SPACING.EXACTLY
+            doc.save("original.docx")
+
+            extract_result = runner.invoke(main, ["extract", "original.docx"])
+            assert extract_result.exit_code == 0, extract_result.output
+            self._assert_styles_json_has_line_spacing_rule(
+                "original.sidedoc", "EXACTLY", expected_spacing
+            )
+
+            result = runner.invoke(main, ["build", "original.sidedoc", "-o", "rebuilt.docx"])
+            assert result.exit_code == 0, result.output
+            self._assert_paragraph_line_spacing(
+                "rebuilt.docx",
+                "Exactly spaced text",
+                WD_LINE_SPACING.EXACTLY,
+                expected_spacing,
+            )
+
+    def test_at_least_line_spacing_rule_survives_roundtrip(self):
+        """At-least line spacing must round-trip with its interpretation rule."""
+        runner = CliRunner()
+        expected_spacing = int(Pt(14))
+        with runner.isolated_filesystem():
+            doc = Document()
+            para = doc.add_paragraph("At least spaced text")
+            para.paragraph_format.line_spacing = Pt(14)
+            para.paragraph_format.line_spacing_rule = WD_LINE_SPACING.AT_LEAST
+            doc.save("original.docx")
+
+            extract_result = runner.invoke(main, ["extract", "original.docx"])
+            assert extract_result.exit_code == 0, extract_result.output
+            self._assert_styles_json_has_line_spacing_rule(
+                "original.sidedoc", "AT_LEAST", expected_spacing
+            )
+
+            result = runner.invoke(main, ["build", "original.sidedoc", "-o", "rebuilt.docx"])
+            assert result.exit_code == 0, result.output
+            self._assert_paragraph_line_spacing(
+                "rebuilt.docx",
+                "At least spaced text",
+                WD_LINE_SPACING.AT_LEAST,
+                expected_spacing,
+            )
+
+    def test_sync_preserves_exact_line_spacing_rule(self):
+        """Sync should preserve exact line spacing after content.md text edits."""
+        runner = CliRunner()
+        expected_spacing = int(Pt(12))
+        with runner.isolated_filesystem():
+            doc = Document()
+            para = doc.add_paragraph("Original exact spacing")
+            para.paragraph_format.line_spacing = Pt(12)
+            para.paragraph_format.line_spacing_rule = WD_LINE_SPACING.EXACTLY
+            doc.save("original.docx")
+
+            extract_result = runner.invoke(main, ["extract", "original.docx"])
+            assert extract_result.exit_code == 0, extract_result.output
+            content_path = Path("original.sidedoc/content.md")
+            content_path.write_text(
+                content_path.read_text().replace(
+                    "Original exact spacing", "Edited exact spacing"
+                )
+            )
+
+            result = runner.invoke(main, ["sync", "original.sidedoc", "-o", "synced.docx"])
+            assert result.exit_code == 0, result.output
+            self._assert_paragraph_line_spacing(
+                "synced.docx",
+                "Edited exact spacing",
+                WD_LINE_SPACING.EXACTLY,
+                expected_spacing,
+            )
 
     # Issue #3: para.style.font.* mutation leaked across paragraphs sharing a style.
     def test_block_style_font_does_not_leak_via_shared_style(self):


### PR DESCRIPTION
Assignee: @jgardner04 ([jonathan](https://linear.app/jonathangardner/profiles/jonathan))

## Summary

- **Apply `docx_style` during reconstruction** — Paragraphs now receive their original Word style (Quote, Title, List Bullet, Heading, etc.) instead of falling back to "Normal"
- **Extract and preserve paragraph format properties** — Indentation (left, right, first-line), spacing (before, after, line), and pagination controls (keep_together, keep_with_next, page_break_before) are now captured during extraction and applied during reconstruction
- **Graceful fallback for missing styles** — When a custom style doesn't exist in the target document, falls back to "Normal" with a `UserWarning`

## Changes

| File | Change |
|------|--------|
| `src/sidedoc/models.py` | Added 9 optional paragraph format fields to `Style` dataclass |
| `src/sidedoc/extract.py` | Extract `paragraph_format` properties during style extraction |
| `src/sidedoc/package.py` | Serialize new fields into `styles.json` |
| `src/sidedoc/reconstruct.py` | Apply `docx_style` first, then direct formatting overrides in `_apply_block_formatting()` |
| `tests/test_style_preservation.py` | 13 new tests covering style application, extraction, round-trip, fallback, and direct formatting override |
| `CHANGELOG.md` | Added entry under `[Unreleased]` |

## Test plan

- [x] `docx_style` applied during reconstruction (Quote, Title, List Bullet, Heading 1/2)
- [x] Missing custom style falls back to Normal with warning
- [x] Paragraph format properties extracted (left_indent, spacing, keep_together, page_break_before)
- [x] Round-trip preserves indentation, spacing, keep_with_next, first_line_indent
- [x] Direct formatting overrides style defaults correctly
- [x] Full test suite passes (514 passed, 0 new failures — 35 pre-existing fixture-not-found failures unchanged)

Closes [JON-91](https://linear.app/jonathangardner/issue/JON-91/enhanced-style-preservation-docx-style-application)

---
> **Tip:** I will respond to comments that @ mention @cyrus-org[bot] on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->